### PR TITLE
Upgrades GitHub actions

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build html
         run: bin/gradle dokkaHtml --no-daemon --stacktrace
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: lib/build/dokka/html
   # Publish job
@@ -29,4 +29,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy GitHub Pages site
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Upgrades actions/upload-pages-artifact and actions/deploy-pages.

actions/upload-pages-artifact v2 was deprecated last year[^0].

[^0]: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/